### PR TITLE
Fix tool path in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
-CC65=	/usr/local/bin/cc65
-CL65=	/usr/local/bin/cl65
+CC65=	cc65
+CL65=	cl65
 COPTS=	-t c64 -O -Or -Oi -Os --cpu 65c02
 LOPTS=	
 


### PR DESCRIPTION
Could we referre the cc-tools without path in the makefile, this would make the windows/cygwin build easier.