### PR TITLE
build from clean checkout and fix USE_LOCAL_CC65 #5 #1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,12 @@ m65fdisk:	$(HEADERS) Makefile fdisk.c fdisk_fat32.c fdisk_hal_unix.c fdisk_memor
 	gcc -Wall -Wno-char-subscripts -o m65fdisk fdisk.c fdisk_fat32.c fdisk_hal_unix.c fdisk_memory.c fdisk_screen.c
 
 clean:
-	rm -f $(FILES)
+	rm -f $(FILES) m65fdisk.map \
+	pngprepare \
+	*.o \
+	fdisk*.s \
+	ascii.h asciih \
+	ascii8x8.bin
 
 cleangen:
 	rm ascii8x8.bin

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,13 @@ HEADERS=	Makefile \
 DATAFILES=	ascii8x8.bin
 
 %.s:	%.c $(HEADERS) $(DATAFILES) $(CC65)
+	$(warning ======== Making: $@)
 	$(CC65) $(COPTS) -o $@ $<
 
 all:	$(FILES)
 
 $(CC65):
+	$(warning ======== Making: $@)
 ifeq ($(USE_LOCAL_CC65),"")
 	git submodule init
 	git submodule update
@@ -48,20 +50,26 @@ else
 endif
 
 ascii8x8.bin: ascii00-ff.png pngprepare
+	$(warning ======== Making: $@)
 	./pngprepare charrom ascii00-ff.png ascii8x8.bin
 
 asciih:	asciih.c
+	$(warning ======== Making: $@)
 	$(CC) -o asciih asciih.c
 ascii.h:	asciih
+	$(warning ======== Making: $@)
 	./asciih
 
 pngprepare:	pngprepare.c
+	$(warning ======== Making: $@)
 	$(CC) -I/usr/local/include -L/usr/local/lib -o pngprepare pngprepare.c -lpng
 
 m65fdisk.prg:	$(ASSFILES) $(DATAFILES) $(CC65)
+	$(warning ======== Making: $@)
 	$(CL65) $(COPTS) $(LOPTS) -vm -m m65fdisk.map -o m65fdisk.prg $(ASSFILES)
 
 m65fdisk:	$(HEADERS) Makefile fdisk.c fdisk_fat32.c fdisk_hal_unix.c fdisk_memory.c fdisk_screen.c
+	$(warning ======== Making: $@)
 	gcc -Wall -Wno-char-subscripts -o m65fdisk fdisk.c fdisk_fat32.c fdisk_hal_unix.c fdisk_memory.c fdisk_screen.c
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 
-ifeq ($(USE_LOCAL_CC65),"")
-CC65=	cc65/bin/cc65
-CL65=	cc65/bin/cl65
+ifdef USE_LOCAL_CC65
+	# use locally installed binary (requires cc65 to be in the $PATH)
+	CC65=cc65
+	CL65=cl65
 else
-CC65=	cc65
-CL65=	cl65
+	# use the binary built from the submodule
+	CC65=cc65/bin/cc65
+	CL65=cc65/bin/cl65
 endif
+
 COPTS=	-t c64 -O -Or -Oi -Os --cpu 65c02 -Icc65/include
 LOPTS=	--asm-include-dir cc65/asminc --cfg-path cc65/cfg --lib-path cc65/lib
 
@@ -39,14 +42,15 @@ DATAFILES=	ascii8x8.bin
 
 all:	$(FILES)
 
+$(CL65):
 $(CC65):
 	$(warning ======== Making: $@)
-ifeq ($(USE_LOCAL_CC65),"")
+ifdef $(USE_LOCAL_CC65)
+	@echo "Using local installed CC65."
+else
 	git submodule init
 	git submodule update
-	( cd cc65 && make -j 8 )
-else
-	@echo "Using local installed CC65."
+	(cd cc65 && make -j 8 )
 endif
 
 ascii8x8.bin: ascii00-ff.png pngprepare

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # mega65-fdisk
-FDISK+Format Utility for MEGA65
+FDISK+Format Utility for MEGA65 (http://github.com/MEGA65)
+
+## Prerequisites
+* need something for ```pngprepare```, -> ```sudo apt install libpng12-dev```
+* the 'cc65' toolchain is required, and by default this is taken care of in the Makefile.  
+Alternatively, you can supply your pre-built ```cc65``` binaries (see below at "CI").
+
+## Building
+* ``make`` will build (including init/update/build of submodule ``./cc65``)
+
+## Continuous Integration (CI)
+For CI building, you may not want to build the cc65-submodule,
+but rather use a locally installed binary instead.
+
+In that case, build with:
+```make USE_LOCAL_CC65=1```
+


### PR DESCRIPTION
will also need to update mega65-core and mega65-freezemenu to be consistent with the USE_LOCAL_CC65 logic