### PR TITLE
fixed 'Duplicate external identifier' error on 'i' var

### DIFF
--- a/fdisk_hal_mega65.c
+++ b/fdisk_hal_mega65.c
@@ -413,7 +413,7 @@ void sdcard_writesector(const uint32_t sector_number)
   
 }
 
-uint16_t i;
+static uint16_t i;
 
 void sdcard_readspeed_test(void)
 {

--- a/fdisk_screen.c
+++ b/fdisk_screen.c
@@ -240,7 +240,7 @@ void screen_colour_line(unsigned char line,unsigned char colour)
 }
 #endif
 
-unsigned char i;
+static unsigned char i;
 
 #ifdef __CC65__
 void fatal_error(unsigned char *filename, unsigned int line_number)


### PR DESCRIPTION
Perhaps I've got a newer version of cc65 that is more strict on global variable names across multiple files, as it reports these as an error.

Fair enough in this case really, as two files defined a global 'i' var, and gave them different types too.