### PR TITLE
fix: fat file system broken after erasing #15

### DIFF
--- a/fdisk_hal_mega65.c
+++ b/fdisk_hal_mega65.c
@@ -681,6 +681,10 @@ void sdcard_erase(const uint32_t first_sector, const uint32_t last_sector)
       // First sector of multi-sector write
       POKE(sd_ctl, 0x04);
     }
+    else if (n == last_sector) {
+      // Last sector of multi-sector write
+      POKE(sd_ctl, 0x06);
+    }
     else
       // All other sectors
       POKE(sd_ctl, 0x05);
@@ -701,18 +705,4 @@ void sdcard_erase(const uint32_t first_sector, const uint32_t last_sector)
     screen_decimal(screen_line_address + 1, last_sector - n);
     //    fprintf(stderr,"."); fflush(stderr);
   }
-
-#ifndef NOFAST_ERASE
-  // Then say when we are done
-  POKE(sd_ctl, 0x57); // open SD card write gate
-  POKE(sd_ctl, 0x06);
-
-  // Wait for SD card to go busy
-  while (!(PEEK(sd_ctl) & 3))
-    continue;
-
-  // Wait for SD card to go ready
-  while (PEEK(sd_ctl) & 3)
-    continue;
-#endif
 }


### PR DESCRIPTION
This PR fixes an issue where multi-sector writes were erasing one sector more than requested. This was overwriting FAT file system sectors already created a step earlier.

When doing multi-sector writes, the command 0x06 should be used for the last sector, not afterwards.