### PR TITLE
Feature/19-erase-config-block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,9 @@ else
 	CL65=cc65/bin/cl65
 endif
 
-COPTS=	-t c64 -O -Or -Oi -Os --cpu 65c02 -Icc65/include
-LOPTS=	--asm-include-dir cc65/asminc --cfg-path cc65/cfg --lib-path cc65/lib
+COPTS=		-t c64 -O -Or -Oi -Os --cpu 65c02 -Icc65/include
+LOPTS=		--asm-include-dir cc65/asminc --cfg-path cc65/cfg --lib-path cc65/lib
+PNGFLAGS=	`pkg-config --cflags --libs libpng`
 
 FILES=		m65fdisk.prg  m65fdisk
 
@@ -82,7 +83,7 @@ ascii.h:	asciih
 
 pngprepare:	pngprepare.c
 	$(warning ======== Making: $@)
-	$(CC) -I/usr/local/include -L/usr/local/lib -o pngprepare pngprepare.c -lpng
+	$(CC) $(PNGFLAGS) -o pngprepare pngprepare.c
 
 m65fdisk.prg:	$(ASSFILES) $(DATAFILES) $(CC65)
 	$(warning ======== Making: $@)

--- a/fdisk_hal.h
+++ b/fdisk_hal.h
@@ -5,6 +5,7 @@
 extern uint8_t sector_buffer[512];
 extern unsigned char sdhc_card;
 
+unsigned char get_random_byte(void);
 uint32_t sdcard_getsize(void);
 void sdcard_open(void);
 void sdcard_writesector(const uint32_t sector_number);

--- a/fdisk_hal_mega65.c
+++ b/fdisk_hal_mega65.c
@@ -20,6 +20,12 @@ const char *prop_m65u_name = "PROP.M65U.NAME=SDCARD FDISK+FORMAT UTILITY";
 unsigned char key = 0;
 uint16_t i;
 
+unsigned char get_random_byte(void)
+{
+  while (PEEK(0xD7FE) & 0x80) continue;
+  return PEEK(0xD7EF);
+}
+
 unsigned char mega65_getkey(void)
 {
   while (!PEEK(0xD610))

--- a/fdisk_hal_unix.c
+++ b/fdisk_hal_unix.c
@@ -3,11 +3,17 @@
 #include <sys/stat.h>
 #include <strings.h>
 #include <termios.h>
+#include <time.h>
 
 #include "fdisk_hal.h"
 
 FILE *sdcard = NULL;
 FILE *flash = NULL;
+
+unsigned char get_random_byte(void)
+{
+  return rand() % 256;
+}
 
 unsigned char sdcard_reset(void)
 {
@@ -60,6 +66,8 @@ uint32_t sdcard_getsize(void)
 
 void sdcard_open(void)
 {
+  srand(time(NULL));
+
   if (!getenv("SDCARDFILE")) {
     fprintf(stderr, "ERROR: Environment variable 'SDCARDFILE' not found!\n");
     fprintf(stderr, "- Please set it to either:\n"


### PR DESCRIPTION
This PR adds erasing the config sector when formatting the SD card. The default values are already valid, but we also set a flag so the machine will boot into onboarding next power-cycle to assist in setting up video and creating a new random MAC address there, as well.