### PR TITLE
Native fixes

### DIFF
--- a/fdisk.c
+++ b/fdisk.c
@@ -1102,10 +1102,14 @@ int format_disk(void)
     slotActive = 0;
     for (i = 0; i < MAX_SLOT; i++) {
       if (!mega65slot[i].version[0] || !mega65slot[i].file_count) continue;
+#ifdef __CC65__
       strcpy(buffer, "(#) MEGA65 -    Files");
       buffer[1] = 0x30 + i;
       format_decimal((int)(buffer + 13), mega65slot[i].file_count, 2);
       write_line(buffer, 3);
+#else
+      fprintf(stdout, "(%d) MEGA65 - %2d Files\n", i, mega65slot[i].file_count);
+#endif
       write_line(mega65slot[i].version, 7);
       if (mega65slot[i].file_count) {
         slotCount++;

--- a/fdisk_hal_unix.c
+++ b/fdisk_hal_unix.c
@@ -122,6 +122,11 @@ void open_flash_file(void)
   fprintf(stderr, "FLASHFILE=%s\n", getenv("FLASHFILE"));
 
   flash = fopen(getenv("FLASHFILE"), "rb+");
+  if (!flash) {
+    fprintf(stderr, "Could not open '%s'...\n", getenv("FLASHFILE"));
+    perror("fopen");
+    exit(-1);
+  }
 }
 
 void flash_read512bytes(const uint32_t byte_offset)


### PR DESCRIPTION
Two small fixes to the native built version:

1. Use `fprintf` instead of `format_decimal` to print the number of embedded files in a core.  clang was complaining about the narrowing cast of a pointer (even though the argument is just discarded, so not really unsafe), and anyway the printout looks much nicer this way.  😸 
2. Check that the `fopen` of `FLASHFILE` really succeeded, so that we don't get a mysterious `NULL` dereference in `fseek`.